### PR TITLE
Grid 64 support

### DIFF
--- a/støy.lua
+++ b/støy.lua
@@ -164,21 +164,21 @@ local g_current    = 15
 -- grid: lights
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-function row_current(row) -- light up the current row, display val rounded to nearest 16th
+function row_current(row) -- light up the current row, display val rounded to nearest grid column
    if not k1_held then	
-      for n = 1, 16 do
+      for n = 1, g.cols do
          g:led(n, row, g_current_bg)
       end
-      for n = 1, math.floor(g_val * 16, 1) do
+      for n = 1, math.floor(g_val * g.cols, 1) do
          g:led(n, row, g_current)
       end
    end
 end
 
-function row_all() -- light up all rows with val rounded to nearest 16th
+function row_all() -- light up all rows with val rounded to nearest grid column
    if not k1_held then
       for row = 1, 8 do
-         for n = 1, math.floor(params:get_raw(p_list[row]) * 16, 1) do
+         for n = 1, math.floor(params:get_raw(p_list[row]) * g.cols, 1) do
             g:led(n, row, g_params)
          end
       end
@@ -186,7 +186,7 @@ function row_all() -- light up all rows with val rounded to nearest 16th
 
    if k1_held then
       for row = 1, 8 do
-         for n = 1, math.floor(params:get_raw(f_list[row]) * 16, 1) do
+         for n = 1, math.floor(params:get_raw(f_list[row]) * g.cols, 1) do
             g:led(n, row, g_current)
          end
       end
@@ -196,7 +196,8 @@ end
 function scanlines_grid() -- draw noisy lines across the grid
    for row = 1, 8 do
       active = math.random(0, 1) * g_scanlines
-      for n = 1, 16 do
+      -- for n = 1, 16 do
+      for n = 1, g.cols do
          g:led(n, row, active)
       end
    end

--- a/støy.lua
+++ b/støy.lua
@@ -104,7 +104,7 @@ g.key = function(x, y, z)
          if y_buff[y][1] == 1 then
             g_val = 0
          else
-            g_val = y_buff[y][1] / 16
+            g_val = y_buff[y][1] / g.cols
          end
       end
       
@@ -115,7 +115,7 @@ g.key = function(x, y, z)
          if y_buff[y][#y_buff[y]] == 1 then
             g_val = 0
          else
-            g_val = y_buff[y][#y_buff[y]] / 16
+            g_val = y_buff[y][#y_buff[y]] / g.cols
          end
       end
       
@@ -131,7 +131,7 @@ g.key = function(x, y, z)
          if y_buff[y][1] == 1 then
             f_val = 0.01
          else
-            f_val = y_buff[y][1] / 16
+            f_val = y_buff[y][1] / g.cols
          end
       end
       
@@ -141,7 +141,7 @@ g.key = function(x, y, z)
          if y_buff[y][#y_buff[y]] == 1 then
             f_val = 0.01
          else
-            f_val = y_buff[y][#y_buff[y]] / 16
+            f_val = y_buff[y][#y_buff[y]] / g.cols
          end
       end
 


### PR DESCRIPTION
Hi, this should fix #8 and implement (hopefully) support for a smaller 64 grid. I just basically changed the hardcoded grid width of 16 columns with [`g.cols`](https://monome.org/docs/norns/reference/grid#query) which is either 16 or 8 depending on the grid size. That seems to work for first of all starting the script, and being able to both display and manipulate the parameters on a grid 64.

Hopefully this didn't break any of the less immediate features behind the alt or the delay. Also I hope the available range of the resonator values was not changed -- my intention was simply to halve the input and output resolution, not range, when used with a smaller grid.

I am working with a Midigrid out of a single Launchpad Mk3 mini, and cannot test either the issue nor the solution on a real grid, sorry. In Midigrid you can choose whether you have a single 64 grid, a single 64 grid with two pages to total up to a 128, or two separate 64 grids which are added side by side.

Let me know if this is at all useful, or where I could improve it if needed. Tak :)